### PR TITLE
Adding license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) 2018 Bjørn Rosell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
   "name": "rosell-dk/webp-convert",
   "description": "Convert jpeg/png to webp with PHP",
   "type": "library",
+  "license": "MIT",
   "autoload": {
     "psr-0": { "WebPConvert": "" }
   },


### PR DESCRIPTION
This pull request ..
- suggests adding MIT license
- updates `composer.json` accordingly

Also, please make sure to submit `webp-convert` to [Packagist](https://packagist.org) (login with Github is possible. I could too, but since I cannot create Packagist auto-update hook / generate an API token, you should do this).

Thanks for great teamwork so far!