### PR TITLE
$failureCodesBesides127 is used to check first position

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.phar
 /vendor
 /tests/*.webp
 /tests/images/*.webp
+.idea

--- a/src/Converters/Cwebp.php
+++ b/src/Converters/Cwebp.php
@@ -272,7 +272,12 @@ class Cwebp
                                 'All failed (exit code: ' . $majorFailCode . '). ';
                     }
                 } else {
-                    $failureCodesBesides127 = array_diff($failureCodes, [127]);
+                    /**
+                     * $failureCodesBesides127 is used to check first position ($failureCodesBesides127[0])
+                     * however position can vary as index can be 1 or something else. array_values() would
+                     * always start from 0.
+                     */
+                    $failureCodesBesides127 = array_values(array_diff($failureCodes, [127]));
 
                     if (count($failureCodesBesides127) == 1) {
                         $majorFailCode = $failureCodesBesides127[0];


### PR DESCRIPTION
`$failureCodesBesides127` is used to check first position later, which can vary as index can be 1 or something else. `array_values()` would always start from 0.

Issue can be replicated once you try to convert image bigger then 16383 pixels in size.