### PR TITLE
fix error in webp conversion

### DIFF
--- a/src/Converters/Gd.php
+++ b/src/Converters/Gd.php
@@ -156,6 +156,13 @@ class Gd extends BaseConverter
             }
         }
 
+
+         // Solve this error -> Fatal error: Paletter image not supported by webp (Error 500 in admin-ajax.php of WordPress)
+        if( function_exists('imagepalettetotruecolor') ){
+            
+            imagepalettetotruecolor($image);
+        }
+
         $success = @imagewebp($image, $this->destination, $this->options['_calculated_quality']);
 
         if (!$success) {


### PR DESCRIPTION
Please, before merge, test it in Unix Compatible Systems (Mac, Linux, etc.). I tested it in Windows 10, XAMPP 7.3.1 and works fine, I was having some trouble because the Webp conversion fails in some png images and then WordPress didn't upload them dispatching HTTP Error 500 via admin-ajax.php (I use the plugin Webp Express).
