### PR TITLE
Add check for filesize after 'successful' conversion

### DIFF
--- a/src/Serve/Report.php
+++ b/src/Serve/Report.php
@@ -176,6 +176,13 @@ class Report
             exit;
         }
 
+        if (!file_exists($destination)){
+            $success = false;
+        }elseif(filesize($destination)==0){
+            @unlink($destination);
+            $success = false;
+        }
+
         if ($success) {
             //echo 'ok';
         } else {

--- a/src/Serve/ServeConverted.php
+++ b/src/Serve/ServeConverted.php
@@ -82,6 +82,16 @@ class ServeConverted extends ServeBase
         try {
             $success = WebPConvert::convert($this->source, $this->destination, $this->options, $bufferLogger);
 
+            if (!file_exists($this->destination)){
+                $success = false;
+            }elseif(filesize($this->destination)==0){
+                @unlink($this->destination);
+                $success = false;
+                $this->whatToServe = 'original';
+                $this->whyServingThis = 'explicitly-told-to';
+                return $this->serveOriginal();
+            }
+
             if ($success) {
                 // Serve source if it is smaller than destination
                 $filesizeDestination = @filesize($this->destination);


### PR DESCRIPTION
I discovered that sometimes, randomly, when using the cwebp conversion tool on centos, the result file is empty and the return is a success.
I added a double check and when it is empty it gets deleted, the original file is served and it can be converted again next time.