### PR TITLE
Fix 'serve-original'

### DIFF
--- a/src/Serve/ServeConvertedWebP.php
+++ b/src/Serve/ServeConvertedWebP.php
@@ -179,6 +179,7 @@ class ServeConvertedWebP
         if ($options['serve-original']) {
             Header::addLogHeader('Serving original (told to)', $serveLogger);
             self::serveOriginal($source, $options['serve-image']);
+            return;
         }
 
         if ($options['redirect-to-self-instead-of-serving']) {


### PR DESCRIPTION
When using 'serve-original' it continues and finally serve the converted file. A 'return' is needed here.