### PR TITLE
Will redirect error output to prevent it from polluting logs

### DIFF
--- a/src/Convert/Converters/Cwebp.php
+++ b/src/Convert/Converters/Cwebp.php
@@ -123,7 +123,7 @@ class Cwebp extends AbstractConverter
     {
         //$version = $this->detectVersion($binary);
 
-        $command = ($useNice ? 'nice ' : '') . $binary . ' ' . $commandOptions;
+        $command = ($useNice ? 'nice ' : '') . $binary . ' ' . $commandOptions . ' 2>&1';
 
         //$logger->logLn('command options:' . $commandOptions);
         $this->logLn('Trying to convert by executing the following command:');
@@ -401,7 +401,7 @@ class Cwebp extends AbstractConverter
 
     private function who()
     {
-        exec('whoami', $whoOutput, $whoReturnCode);
+        exec('whoami 2>&1', $whoOutput, $whoReturnCode);
         if (($whoReturnCode == 0) && (isset($whoOutput[0]))) {
             return 'user: "' . $whoOutput[0] . '"';
         } else {
@@ -415,7 +415,7 @@ class Cwebp extends AbstractConverter
      */
     private function detectVersion($binary)
     {
-        $command = $binary . ' -version';
+        $command = $binary . ' -version 2>&1';
         $this->log('- Executing: ' . $command);
         exec($command, $output, $returnCode);
 

--- a/src/Convert/Converters/GraphicsMagick.php
+++ b/src/Convert/Converters/GraphicsMagick.php
@@ -46,13 +46,13 @@ class GraphicsMagick extends AbstractConverter
 
     public function isInstalled()
     {
-        exec($this->getPath() . ' -version', $output, $returnCode);
+        exec($this->getPath() . ' -version 2>&1', $output, $returnCode);
         return ($returnCode == 0);
     }
 
     public function getVersion()
     {
-        exec($this->getPath() . ' -version', $output, $returnCode);
+        exec($this->getPath() . ' -version 2>&1', $output, $returnCode);
         if (($returnCode == 0) && isset($output[0])) {
             return preg_replace('#http.*#', '', $output[0]);
         }
@@ -62,7 +62,7 @@ class GraphicsMagick extends AbstractConverter
     // Check if webp delegate is installed
     public function isWebPDelegateInstalled()
     {
-        exec($this->getPath() . ' -version', $output, $returnCode);
+        exec($this->getPath() . ' -version 2>&1', $output, $returnCode);
         foreach ($output as $line) {
             if (preg_match('#WebP.*yes#i', $line)) {
                 return true;
@@ -142,7 +142,7 @@ class GraphicsMagick extends AbstractConverter
 
         $this->logLn('Version: ' . $this->getVersion());
 
-        $command = $this->getPath() . ' convert ' . $this->createCommandLineOptions();
+        $command = $this->getPath() . ' convert ' . $this->createCommandLineOptions() . ' 2>&1';
 
         $useNice = (($this->options['use-nice']) && self::hasNiceSupport()) ? true : false;
         if ($useNice) {

--- a/src/Convert/Converters/ImageMagick.php
+++ b/src/Convert/Converters/ImageMagick.php
@@ -47,7 +47,7 @@ class ImageMagick extends AbstractConverter
 
     private function getVersion()
     {
-        exec($this->getPath() . ' -version', $output, $returnCode);
+        exec($this->getPath() . ' -version 2>&1', $output, $returnCode);
         if (($returnCode == 0) && isset($output[0])) {
             return $output[0];
         } else {
@@ -57,15 +57,14 @@ class ImageMagick extends AbstractConverter
 
     public function isInstalled()
     {
-        exec($this->getPath() . ' -version', $output, $returnCode);
+        exec($this->getPath() . ' -version 2>&1', $output, $returnCode);
         return ($returnCode == 0);
     }
 
     // Check if webp delegate is installed
     public function isWebPDelegateInstalled()
     {
-
-        exec('convert -list delegate', $output, $returnCode);
+        exec('convert -list delegate 2>&1', $output, $returnCode);
         foreach ($output as $line) {
             if (preg_match('#webp\\s*=#i', $line)) {
                 return true;
@@ -73,7 +72,7 @@ class ImageMagick extends AbstractConverter
         }
 
         // try other command
-        exec('convert -list configure', $output, $returnCode);
+        exec('convert -list configure 2>&1', $output, $returnCode);
         foreach ($output as $line) {
             if (preg_match('#DELEGATE.*webp#i', $line)) {
                 return true;
@@ -153,7 +152,7 @@ class ImageMagick extends AbstractConverter
     {
         $this->logLn($this->getVersion());
 
-        $command = $this->getPath() . ' ' . $this->createCommandLineOptions();
+        $command = $this->getPath() . ' ' . $this->createCommandLineOptions() . ' 2>&1';
 
         $useNice = (($this->options['use-nice']) && self::hasNiceSupport()) ? true : false;
         if ($useNice) {

--- a/src/Helpers/BinaryDiscovery.php
+++ b/src/Helpers/BinaryDiscovery.php
@@ -52,7 +52,7 @@ class BinaryDiscovery
     private static function discoverBinariesUsingWhereIs($binary)
     {
         // This method was added due to #226.
-        exec('whereis -b ' . $binary, $output, $returnCode);
+        exec('whereis -b ' . $binary . ' 2>&1', $output, $returnCode);
         if (($returnCode == 0) && (isset($output[0]))) {
             $result = $output[0];
             // Ie: "cwebp: /usr/bin/cwebp /usr/local/bin/cwebp"
@@ -74,7 +74,7 @@ class BinaryDiscovery
     {
         // As suggested by @cantoute here:
         // https://wordpress.org/support/topic/sh-1-usr-local-bin-cwebp-not-found/
-        exec('which -a ' . $binary, $output, $returnCode);
+        exec('which -a ' . $binary . ' 2>&1', $output, $returnCode);
         if ($returnCode == 0) {
             return $output;
         }


### PR DESCRIPTION
Added error redirection to places where `exec()` command is used to prevent pollution of log files and CLI output

Fixes #233