### PR TITLE
Serve original file even if it is not a JPG/PNG

### DIFF
--- a/src/Serve/ServeConvertedWebP.php
+++ b/src/Serve/ServeConvertedWebP.php
@@ -4,6 +4,7 @@ namespace WebPConvert\Serve;
 use WebPConvert\Convert\Exceptions\ConversionFailedException;
 use WebPConvert\Helpers\InputValidator;
 use WebPConvert\Helpers\MimeType;
+use WebPConvert\Helpers\PathChecker;
 use WebPConvert\Serve\Exceptions\ServeFailedException;
 use WebPConvert\Serve\Header;
 use WebPConvert\Serve\Report;
@@ -72,7 +73,10 @@ class ServeConvertedWebP
      */
     public static function serveOriginal($source, $serveImageOptions = [])
     {
-        InputValidator::checkSource($source);
+        // Check if the file exists
+        PathChecker::checkSourcePath($source);
+        // Only serve image type
+        InputValidator::checkMimeType($source, ['image/jpeg','image/png','image/webp','image/gif']);
         $contentType = MimeType::getMimeTypeDetectionResult($source);
         if (is_null($contentType)) {
             throw new ServeFailedException('Rejecting to serve original (mime type cannot be determined)');


### PR DESCRIPTION
I got a case where the original/source file was already in webp format, it throws an error which is correct but there was an error serving the original file because it is not a JPG or PNG. I think we can serve the orinigal as long as it is an image.
I don't know if I fixed it the way it should but at least it's a solution.
Thank you for this great library anyway!