### PR TITLE
Suppressed PHP warnings for rename and unlink operations

### DIFF
--- a/src/Convert/Converters/AbstractConverter.php
+++ b/src/Convert/Converters/AbstractConverter.php
@@ -260,7 +260,7 @@ abstract class AbstractConverter
         if (!@file_exists($destination)) {
             throw new ConversionFailedException('Destination file is not there: ' . $destination);
         } elseif (@filesize($destination) === 0) {
-            unlink($destination);
+            @unlink($destination);
             throw new ConversionFailedException('Destination file was completely empty');
         } else {
             if (!isset($this->options['_suppress_success_message'])) {

--- a/src/Convert/Converters/BaseTraits/DestinationPreparationTrait.php
+++ b/src/Convert/Converters/BaseTraits/DestinationPreparationTrait.php
@@ -70,7 +70,7 @@ trait DestinationPreparationTrait
         // No harm in doing that for non-Windows systems either.
         if (file_put_contents($destination, 'dummy') !== false) {
             // all is well, after all
-            unlink($destination);
+            @unlink($destination);
             return;
         }
 
@@ -91,7 +91,7 @@ trait DestinationPreparationTrait
         if (file_exists($destination)) {
             // A file already exists in this folder...
             // We delete it, to make way for a new webp
-            if (!unlink($destination)) {
+            if (!@unlink($destination)) {
                 throw new CreateDestinationFileException(
                     'Existing file cannot be removed: ' . basename($destination)
                 );

--- a/src/Convert/Converters/ConverterTraits/EncodingAutoTrait.php
+++ b/src/Convert/Converters/ConverterTraits/EncodingAutoTrait.php
@@ -69,12 +69,12 @@ trait EncodingAutoTrait
 
         if (filesize($destinationLossless) > filesize($destinationLossy)) {
             $this->logLn('Picking lossy');
-            unlink($destinationLossless);
-            rename($destinationLossy, $destination);
+            @unlink($destinationLossless);
+            @rename($destinationLossy, $destination);
         } else {
             $this->logLn('Picking lossless');
-            unlink($destinationLossy);
-            rename($destinationLossless, $destination);
+            @unlink($destinationLossy);
+            @rename($destinationLossless, $destination);
         }
         $this->setDestination($destination);
         $this->setOption('encoding', 'auto');

--- a/src/Convert/Converters/Gd.php
+++ b/src/Convert/Converters/Gd.php
@@ -323,7 +323,7 @@ class Gd extends AbstractConverter
     {
         imagedestroy($image);
         if (file_exists($this->destination)) {
-            unlink($this->destination);
+            @unlink($this->destination);
         }
     }
 


### PR DESCRIPTION
In our project, we occasionally encounter warnings when the `unlink/rename` operations fail. This issue arises infrequently when another PHP process unlinks the file between the execution of `file_exists()` and `unlink()`. As a result, the `unlink()` operation fails, generating a warning. This PR addresses the issue by suppressing all warnings associated with both `unlink()` and `rename()` functions.