### PR TITLE
PHP 7.4 fix warning E_STRICT is deprecated

### DIFF
--- a/src/Convert/Converters/BaseTraits/WarningLoggerTrait.php
+++ b/src/Convert/Converters/BaseTraits/WarningLoggerTrait.php
@@ -79,7 +79,6 @@ trait WarningLoggerTrait
         $errorTypes = [
             E_WARNING =>             "Warning",
             E_NOTICE =>              "Notice",
-            E_STRICT =>              "Strict Notice",
             E_DEPRECATED =>          "Deprecated",
             E_USER_DEPRECATED =>     "User Deprecated",
 
@@ -95,6 +94,10 @@ trait WarningLoggerTrait
             in that case, remember to add them to this array
             */
         ];
+
+        if (PHP_VERSION_ID < 70400) {
+            $errorTypes[E_STRICT] = "Strict Notice";
+        }
 
         if (isset($errorTypes[$errno])) {
             $errType = $errorTypes[$errno];


### PR DESCRIPTION
See https://php.watch/versions/8.4/E_STRICT-deprecated
```
Deprecated: Constant E_STRICT is deprecated in /var/www/vendor/rosell-dk/webp-convert/src/Convert/Converters/BaseTraits/WarningLoggerTrait.php on line 82
```