### PR TITLE
Fix: only call imagedestroy() on PHP < 8

### DIFF
--- a/src/Convert/Converters/Gd.php
+++ b/src/Convert/Converters/Gd.php
@@ -160,10 +160,10 @@ class Gd extends AbstractConverter
                 }
             }
             if ($success) {
-                imagedestroy($image);
+                $this->destroyImage($image);
                 $image = $dst;
             } else {
-                imagedestroy($dst);
+                $this->destroyImage($dst);
             }
             return $success;
         } else {
@@ -321,7 +321,7 @@ class Gd extends AbstractConverter
      */
     protected function destroyAndRemove($image)
     {
-        imagedestroy($image);
+        $this->destroyImage($image);
         if (file_exists($this->destination)) {
             @unlink($this->destination);
         }
@@ -531,6 +531,22 @@ class Gd extends AbstractConverter
         $this->tryConverting($image);
 
         // End of story
-        imagedestroy($image);
+        $this->destroyImage($image);
+    }
+
+    /**
+     * Safely destroy GD image resource.
+     *
+     * imagedestroy() has no effect since PHP 8.0 and is deprecated in PHP 8.5.
+     * This wrapper avoids deprecation warnings while keeping backward compatibility.
+     *
+     * @param resource|\GdImage|null $image
+     * @return void
+     */
+    private function destroyImage($image)
+    {
+        if (PHP_VERSION_ID < 80000 && is_resource($image)) {
+            imagedestroy($image);
+        }
     }
 }


### PR DESCRIPTION
Added a check so that imagedestroy() is only called on PHP versions below 8, preventing unnecessary calls on newer PHP versions where it has no effect.

Private function added which will wrap & avoids deprecation warnings while keeping backward compatibility.

imagedestroy() has no effect since PHP 8.0 and is deprecated in PHP 8.5.