### PR TITLE
Remove curl deprecated calls for PHP 8.4/8.5

### DIFF
--- a/src/Convert/Converters/ConverterTraits/CurlTrait.php
+++ b/src/Convert/Converters/ConverterTraits/CurlTrait.php
@@ -77,4 +77,19 @@ trait CurlTrait
         }
         return $ch;
     }
+
+    /**
+     * Close curl.
+     *
+     * Before PHP 8.0, we need to call curl_close
+     * After PHP 8.0, PHP is smart enough to destroy the object by itself
+     *
+     * @param resource|\CurlHandle $curlHandle
+     */
+    protected static function closeCurl($curlHandle)
+    {
+        if (PHP_VERSION_ID < 80000) {
+            curl_close($curlHandle);
+        }
+    }
 }

--- a/src/Convert/Converters/ConverterTraits/CurlTrait.php
+++ b/src/Convert/Converters/ConverterTraits/CurlTrait.php
@@ -84,7 +84,7 @@ trait CurlTrait
      * Before PHP 8.0, we need to call curl_close
      * After PHP 8.0, PHP is smart enough to destroy the object by itself
      *
-     * @param resource|\CurlHandle $curlHandle
+     * @param resource $curlHandle
      */
     protected static function closeCurl($curlHandle)
     {

--- a/src/Convert/Converters/Ewww.php
+++ b/src/Convert/Converters/Ewww.php
@@ -177,7 +177,6 @@ class Ewww extends AbstractConverter
                 'Accept: image/*'
             ],
             CURLOPT_POSTFIELDS => $postData,
-            CURLOPT_BINARYTRANSFER => true,
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_HEADER => false,
             CURLOPT_SSL_VERIFYPEER => false
@@ -198,7 +197,7 @@ class Ewww extends AbstractConverter
         $contentType = curl_getinfo($ch, CURLINFO_CONTENT_TYPE);
         if (($contentType != 'application/octet-stream') && ($contentType != 'image/webp')) {
             //echo curl_getinfo($ch, CURLINFO_CONTENT_TYPE);
-            curl_close($ch);
+            self::closeCurl($ch);
 
             /*
             For bogus or expired key it returns:  {"error":"invalid","t":"exceeded"}
@@ -274,7 +273,6 @@ class Ewww extends AbstractConverter
                 'quality' => 60,
                 'metadata' => 0
             ],
-            CURLOPT_BINARYTRANSFER => true,
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_HEADER => false,
             CURLOPT_SSL_VERIFYPEER => false
@@ -287,7 +285,7 @@ class Ewww extends AbstractConverter
         }
         $contentType = curl_getinfo($ch, CURLINFO_CONTENT_TYPE);
         if (($contentType != 'application/octet-stream') && ($contentType != 'image/webp')) {
-            curl_close($ch);
+            self::closeCurl($ch);
 
             /* May return this: {"error":"invalid","t":"exceeded"} */
             $responseObj = json_decode($response);
@@ -335,7 +333,7 @@ class Ewww extends AbstractConverter
         if (curl_errno($ch)) {
             throw new \Exception(curl_error($ch));
         }
-        curl_close($ch);
+        self::closeCurl($ch);
 
         // Possible responses:
         // “great” = verification successful

--- a/src/Convert/Converters/Wpc.php
+++ b/src/Convert/Converters/Wpc.php
@@ -240,23 +240,23 @@ class Wpc extends AbstractConverter
         if ($host === false || $host === null) {
             return false;
         }
-    
+
         if (strcasecmp($host, 'localhost') === 0) {
             return false;
         }
 
         $ips = self::urlToIps($url);
-    
+
         if (empty($ips)) {
             return false;
         }
-    
+
         foreach ($ips as $ip) {
             if (!self::isPublicIp($ip)) {
                 return false;
             }
         }
-    
+
         return true;
     }
 
@@ -426,7 +426,6 @@ class Wpc extends AbstractConverter
             CURLOPT_URL => $this->getApiUrl(),
             CURLOPT_POST => 1,
             CURLOPT_POSTFIELDS => $this->createPostData(),
-            CURLOPT_BINARYTRANSFER => true,
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_HEADER => false,
             CURLOPT_SSL_VERIFYPEER => false
@@ -442,7 +441,7 @@ class Wpc extends AbstractConverter
         // Check if we got a 404
         $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
         if ($httpCode == 404) {
-            curl_close($ch);
+            self::closeCurl($ch);
             throw new ConversionFailedException(
                 'WPC was not found at the specified URL - we got a 404 response.'
             );
@@ -461,7 +460,7 @@ class Wpc extends AbstractConverter
         // Images has application/octet-stream.
         // Verify that we got an image back.
         if (curl_getinfo($ch, CURLINFO_CONTENT_TYPE) != 'application/octet-stream') {
-            curl_close($ch);
+            self::closeCurl($ch);
 
             if (substr($response, 0, 1) == '{') {
                 $responseObj = json_decode($response, true);
@@ -502,7 +501,7 @@ class Wpc extends AbstractConverter
         }
 
         $success = file_put_contents($this->destination, $response);
-        curl_close($ch);
+        self::closeCurl($ch);
 
         if (!$success) {
             throw new ConversionFailedException('Error saving file. Check file permissions');


### PR DESCRIPTION
Removes some deprecated curl code lines:

1. `CURLOPT_BINARYTRANSFER` is no longer needed since PHP 5.5 according to the [official docs](https://www.php.net/manual/en/curl.constants.php#:~:text=This%20constant%20is%20no%20longer%20used%20as%20of%20PHP%205.5.0.%20Deprecated%20as%20of%20PHP%208.4.0.) or no longer needed since PHP 5.1.2 according to [another source](https://php.watch/versions/8.4/CURLOPT_BINARYTRANSFER-deprecated). It's also deprecated since PHP 8.4. Since this module requires at the minimum PHP 5.6, it should be fine to remove it.
2. Calling `curl_close` [has no effect since PHP 8.0](https://www.php.net/manual/en/function.curl-close.php#:~:text=This%20function%20has%20no%20effect.%20Prior%20to%20PHP%208.0.0%2C%20this%20function%20was%20used%20to%20close%20the%20resource) and was deprecated in PHP 8.5. So I'm wrapping it around a check to only call it when PHP is lower then 8.0

@rosell-dk: since you've been active today, could you spare a few minutes to review and test these changes? And also to take a look at: https://github.com/rosell-dk/webp-convert/pull/358?
We're going to upgrade one of our projects that uses this library to PHP 8.5 and we'd like to get rid of deprecation warnings. 

Many thanks!