### PR TITLE
Add GIF input support

### DIFF
--- a/src/Convert/Converters/BaseTraits/OptionsTrait.php
+++ b/src/Convert/Converters/BaseTraits/OptionsTrait.php
@@ -317,6 +317,13 @@ trait OptionsTrait
             }
         }
 
+        if (isset($this->providedOptions['gif'])) {
+            if ($this->getMimeTypeOfSource() == 'image/gif') {
+                $this->providedOptions = array_merge($this->providedOptions, $this->providedOptions['gif']);
+                unset($this->providedOptions['gif']);
+            }
+        }
+
         // merge down converter-prefixed options
         $converterId = self::getConverterId();
         $strLen = strlen($converterId);

--- a/src/Convert/Converters/Gd.php
+++ b/src/Convert/Converters/Gd.php
@@ -96,6 +96,15 @@ class Gd extends AbstractConverter
                         'Gd has been compiled without Jpeg support and can therefore not convert this jpeg image.'
                     );
                 }
+                break;
+
+            case 'image/gif':
+                if (!function_exists('imagecreatefromgif')) {
+                    throw new SystemRequirementsNotMetException(
+                        'Gd has been compiled without GIF support and can therefore not convert this gif image.'
+                    );
+                }
+                break;
         }
     }
 
@@ -220,6 +229,15 @@ class Gd extends AbstractConverter
                 if ($image === false) {
                     throw new ConversionFailedException(
                         'Gd failed when trying to load/create image (imagecreatefromjpeg() failed)'
+                    );
+                }
+                return $image;
+
+            case 'image/gif':
+                $image = imagecreatefromgif($this->source);
+                if ($image === false) {
+                    throw new ConversionFailedException(
+                        'Gd failed when trying to load/create image (imagecreatefromgif() failed)'
                     );
                 }
                 return $image;

--- a/src/Convert/Converters/Gmagick.php
+++ b/src/Convert/Converters/Gmagick.php
@@ -80,6 +80,13 @@ class Gmagick extends AbstractConverter
                     );
                 }
                 break;
+            case 'image/gif':
+                if (!in_array('GIF', $im->queryFormats())) {
+                    throw new SystemRequirementsNotMetException(
+                        'Gmagick has been compiled without GIF support and can therefore not convert this GIF image.'
+                    );
+                }
+                break;
         }
     }
 

--- a/src/Convert/Converters/Imagick.php
+++ b/src/Convert/Converters/Imagick.php
@@ -80,6 +80,13 @@ class Imagick extends AbstractConverter
                     );
                 }
                 break;
+            case 'image/gif':
+                if (!in_array('GIF', $im->queryFormats('GIF'))) {
+                    throw new SystemRequirementsNotMetException(
+                        'Imagick has been compiled without GIF support and can therefore not convert this GIF image.'
+                    );
+                }
+                break;
         }
     }
 

--- a/src/Helpers/InputValidator.php
+++ b/src/Helpers/InputValidator.php
@@ -19,7 +19,8 @@ class InputValidator
 
     private static $allowedMimeTypes = [
         'image/jpeg',
-        'image/png'
+        'image/png',
+        'image/gif'
     ];
 
     /**


### PR DESCRIPTION
## Add GIF input support

This adds `image/gif` as a supported source type, so GIF images can be converted to WebP the same way PNG and JPEG already are.

### Changes
- **`InputValidator`** – allow `image/gif` through the input mime-type gate
- **`Gd`** – load the source via `imagecreatefromgif()`, with the usual *"compiled without GIF support"* availability check
- **`Imagick` / `Gmagick`** – accept `image/gif` (checks that `GIF` is present in `queryFormats()`)
- **`OptionsTrait`** – support a `gif` option group, mirroring the existing `png` / `jpeg` groups

### Notes / limitations
- **Animated GIFs** are converted to a **single (first) frame** static WebP – this matches GD's `imagecreatefromgif()` behaviour.
- For option handling, GIF currently falls into the same default option group as JPEG (the `$imageType` ternary in `OptionsTrait::setProvidedOptions()`), in addition to the dedicated `gif` group added here. Happy to switch GIF to the PNG/lossless path instead if you'd prefer.

### Real-world use
This patch has been running in production for a while as part of a PrestaShop WebP module, converting user-uploaded GIFs without issues.
